### PR TITLE
button green to dowload RDF

### DIFF
--- a/webapp/templates/dataset_label.html
+++ b/webapp/templates/dataset_label.html
@@ -269,7 +269,7 @@
 
                     <div class="col-sm-4 text-center">
                         <a href="/dataset/assessment/rdf?id={{ dataset_id }}">
-                            <button type="button" class="btn btn-secondary">Download RDF label</button>
+                            <button type="button" class="btn btn-success">Download RDF label</button>
                         </a>
                     </div>
 


### PR DESCRIPTION
I changed the colour from grey to green (btn-success) because in this way on the page we have 3 types of buttons:
- grey (top part) showing instruction on how to interpret the label and other features
- blue to come back to the main page or to the assessment 
- green to download the rdf (and in the future also the PDF version)