### PR TITLE
Fix CRLF line endings for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
## Summary

This PR fixes a Docker startup issue (#175) where the web app container could fail to run `docker/entrypoint.sh` with a misleading “file not found” error.

The Dockerfile already copied the script correctly:

```dockerfile
COPY docker/entrypoint.sh /entrypoint.sh
CMD ["/entrypoint.sh"]
```

The actual issue was that docker/entrypoint.sh used Windows CRLF line endings. In Linux containers, this can cause the shebang to be interpreted as /bin/bash\r, making the entrypoint fail even though the file exists.

### Changes
Converted docker/entrypoint.sh from CRLF to Unix LF line endings.
Added .gitattributes to keep shell scripts using LF endings:

```bash
*.sh text eol=lf
```